### PR TITLE
Auto-disable failing variants

### DIFF
--- a/fast_abtest/__init__.py
+++ b/fast_abtest/__init__.py
@@ -1,4 +1,4 @@
 from .decorator import ab_test
 from .metrics import Metric
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/fast_abtest/interface.py
+++ b/fast_abtest/interface.py
@@ -1,9 +1,15 @@
-from typing import Protocol, Callable
+from typing import Protocol, Callable, Self
 
 from fast_abtest.registred_scenario import R, ScenarioHandler
 
 
 class ABTestFunction(Protocol[R]):
-    def __call__(self, *args, **kwargs) -> R: ...
+    def __call__(self: Self, *args, **kwargs) -> R: ...
 
-    def register_variant(self, traffic_percent: int) -> Callable[[ScenarioHandler[R]], ScenarioHandler[R]]: ...
+    def register_variant(
+        self: Self,
+        traffic_percent: int,
+        disable_threshold: float = 1.0,
+    ) -> Callable[[ScenarioHandler[R]], ScenarioHandler[R]]: ...
+
+    def enable_variant(self: Self, variant_name: str) -> None: ...

--- a/fast_abtest/registred_scenario.py
+++ b/fast_abtest/registred_scenario.py
@@ -1,15 +1,21 @@
 import inspect
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from logging import Logger
 from random import randint
-from typing import Callable, TypeVar, Generic, Protocol
+from threading import Lock
+from typing import Callable, TypeVar, Generic, Protocol, Iterable
 
 from typing_extensions import Self
+
+from .metrics import Metric
 
 R = TypeVar("R")
 R_co = TypeVar("R_co", covariant=True)
 
 
 class ScenarioHandler(Protocol[R_co]):
+    __name__: str
+
     def __call__(self, *args, **kwargs) -> R_co: ...
 
 
@@ -17,27 +23,68 @@ class ScenarioHandler(Protocol[R_co]):
 class _ScenarioVariant(Generic[R]):
     handler: ScenarioHandler[R]
     traffic_percent: int
+    threshold: float
+    call_count: int = 0
+    error_count: int = 0
+    is_active: bool = True
+    _lock: Lock = field(default_factory=Lock, init=False)
+
+    def increment_call(self: Self) -> None:
+        with self._lock:
+            self.call_count += 1
+
+    def threshold_exceeded(self: Self) -> bool:
+        with self._lock:
+            self.error_count += 1
+            if self.error_count / max(self.call_count, 1) > self.threshold:
+                self.is_active = False
+                return True
+        return False
 
 
 class RegisteredScenario(Generic[R]):
-    def __init__(self: Self, main_scenario: _ScenarioVariant[R]) -> None:
+    EXCEEDING_THRESHOLD_WARNING = "Variant {} disabled by error rate (error rate: {:.2}"
+
+    def __init__(
+        self: Self,
+        main_scenario: _ScenarioVariant[R],
+        metrics: Iterable[Metric | Callable],
+        logger: Logger,
+    ) -> None:
         self._variants: list[_ScenarioVariant[R]] = []
+        self._metrics = metrics
         self._main_scenario = main_scenario
         self._main_scenario_signature = self._normalize_signature(inspect.signature(self._main_scenario.handler))
         self._is_async = inspect.iscoroutinefunction(self._main_scenario.handler)
+        self._logger = logger
 
-    def register_variant(self: Self, traffic_percent: int) -> Callable[[ScenarioHandler[R]], ScenarioHandler[R]]:
+    def register_variant(
+        self: Self,
+        traffic_percent: int,
+        disable_threshold: float = 1.0,
+    ) -> Callable[[ScenarioHandler[R]], ScenarioHandler[R]]:
         def add_to_variants(variant_func: ScenarioHandler[R]) -> ScenarioHandler[R]:
             variant_func = self._validate_variant_signature(variant_func)
             variant_func = self._validate_sync_type(variant_func)
-            scenario_variant = _ScenarioVariant(handler=variant_func, traffic_percent=tp)
+            scenario_variant = _ScenarioVariant(
+                handler=variant_func,
+                traffic_percent=tp,
+                threshold=threshold,
+            )
             self._variants.append(scenario_variant)
             self._main_scenario.traffic_percent -= tp
             self._validate_total_traffic()
             return variant_func
 
         tp = self._validate_traffic_value(traffic_percent)
+        threshold = self._validate_disable_threshold(disable_threshold)
         return add_to_variants
+
+    def enable_variant(self: Self, variant_name: str) -> None:
+        for variant in self._variants:
+            if variant.handler.__name__ == variant_name:
+                variant.is_active = True
+                variant.error_count = 0
 
     def _validate_sync_type(self: Self, func: ScenarioHandler[R]) -> ScenarioHandler[R]:
         if inspect.iscoroutinefunction(func) != self._is_async:
@@ -54,6 +101,22 @@ class RegisteredScenario(Generic[R]):
             )
         return func
 
+    def _validate_total_traffic(self: Self) -> None:
+        if self._main_scenario.traffic_percent < 0:
+            raise ValueError("Total traffic percentage exceeds 100")
+
+    @staticmethod
+    def _validate_traffic_value(traffic: int) -> int:
+        if not 1 <= traffic <= 99:
+            raise ValueError("traffic_percent must be between 1 and 99")
+        return int(traffic)
+
+    @staticmethod
+    def _validate_disable_threshold(threshold: float) -> float:
+        if not 0.01 <= threshold <= 1.0:
+            raise ValueError("threshold must be between 0.01 and 1.0")
+        return float(threshold)
+
     @staticmethod
     def _normalize_signature(sig: inspect.Signature) -> str:
         params = []
@@ -68,16 +131,6 @@ class RegisteredScenario(Generic[R]):
             )
         return f"({', '.join(params)}) -> {sig.return_annotation}"
 
-    def _validate_total_traffic(self: Self) -> None:
-        if self._main_scenario.traffic_percent < 0:
-            raise ValueError("Total traffic percentage exceeds 100")
-
-    @staticmethod
-    def _validate_traffic_value(traffic: int) -> int:
-        if not 1 <= traffic <= 99:
-            raise ValueError("traffic_percent must be between 1 and 99")
-        return int(traffic)
-
     def __call__(
         self: Self,
         *args,
@@ -86,8 +139,21 @@ class RegisteredScenario(Generic[R]):
         rand = randint(1, 100)
         current = 0
         for variant in self._variants:
+            if not variant.is_active:
+                continue
+
             current += variant.traffic_percent
             if rand <= current:
-                return variant.handler(*args, **kwargs)
+                variant.increment_call()
+                try:
+                    return variant.handler(*args, **kwargs)
+                except:
+                    if variant.threshold_exceeded():
+                        msg = self.EXCEEDING_THRESHOLD_WARNING.format(
+                            variant.handler.__name__,
+                            variant.error_count / variant.call_count,
+                        )
+                        self._logger.warning(msg)
+                    raise
 
         return self._main_scenario.handler(*args, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "fast-abtest"
-version = "0.1.0"
+version = "0.2.0"
 description = "A fast and lightweight A/B testing library for Python."
 authors = ["Evgenii Eliseev <evgeniieliseeve@gmail.com>"]
 license = "MIT"
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Typing :: Typed",
     "Topic :: Software Development :: Libraries",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,3 +47,8 @@ uvicorn = "^0.34.3"
 [mypy]
 python_version = "3.12"
 strict = true
+
+[tool.pytest.ini_options]
+pythonpath = [
+  "."
+]

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -58,15 +58,15 @@ def test_multiple_variants(reset_random) -> None:
 
     @ab_test(metrics=[])
     def recommend(user_id: int) -> str:
-        return "A"  # Base variant
+        return "A"
 
     @recommend.register_variant(traffic_percent=20)
     def recommend_b(user_id: int) -> str:
-        return "B"  # 20%
+        return "B"
 
     @recommend.register_variant(traffic_percent=30)
     def recommend_c(user_id: int) -> str:
-        return "C"  # 30%
+        return "C"
 
     results = [recommend(1) for _ in range(1000)]
     assert set(results) == {"A", "B", "C"}

--- a/tests/test_error_rate_threshold.py
+++ b/tests/test_error_rate_threshold.py
@@ -1,0 +1,92 @@
+import logging
+from random import seed
+from unittest.mock import patch
+
+import pytest
+
+from fast_abtest import ab_test
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def reset_random():
+    seed(42)
+
+
+def test_variant_disabling_on_errors(reset_random):
+    """Test that variant gets disabled when error threshold is exceeded"""
+    error_count = 0
+
+    @ab_test(metrics=[])
+    def process_request():
+        return "success"
+
+    @process_request.register_variant(traffic_percent=50, disable_threshold=0.3)
+    def process_request_b():
+        nonlocal error_count
+        error_count += 1
+        if error_count <= 4:
+            raise ValueError("Simulated error")
+        return "recovered"
+
+    assert process_request._variants[0].is_active is True
+
+    results = []
+    for _ in range(100):
+        try:
+            results.append(process_request())
+        except ValueError:
+            pass
+
+    assert process_request._variants[0].is_active is False
+
+
+def test_enable_variant_reactivation():
+    """Test that enable_variant reactivates a disabled variant"""
+    error_count = 0
+
+    @ab_test(metrics=[])
+    def api_endpoint():
+        return "default"
+
+    @api_endpoint.register_variant(traffic_percent=70, disable_threshold=0.5)
+    def api_endpoint_b():
+        nonlocal error_count
+        error_count += 1
+        if error_count <= 2:
+            raise RuntimeError("Temporary failure")
+        return "premium"
+
+    for _ in range(3):
+        try:
+            api_endpoint()
+        except RuntimeError:
+            pass
+
+    assert api_endpoint._variants[0].is_active is False
+    api_endpoint.enable_variant("api_endpoint_b")
+    assert api_endpoint._variants[0].is_active is True
+
+
+def test_threshold_edge_cases():
+    """Test edge cases for error threshold"""
+    with pytest.raises(ValueError, match="threshold must be between"):
+
+        @ab_test(metrics=[])
+        def func():
+            pass
+
+        @func.register_variant(traffic_percent=90, disable_threshold=1.1)
+        def func_b(): ...
+
+    with pytest.raises(ValueError, match="threshold must be between"):
+
+        @ab_test(metrics=[])
+        def sensitive_endpoint():
+            return "ok"
+
+        @sensitive_endpoint.register_variant(traffic_percent=50, disable_threshold=0.0)
+        def sensitive_endpoint_b():
+            raise ValueError("Critical error")


### PR DESCRIPTION
Added the optional disable_threshold argument to register_variant. 
The option suspends traffic redirection when the specified error rate value is exceeded.
Redirection can be resumed by calling the enable_variant method.