### PR TITLE
Base monitoring

### DIFF
--- a/fast_abtest/__init__.py
+++ b/fast_abtest/__init__.py
@@ -1,4 +1,5 @@
 from .decorator import ab_test
 from fast_abtest.monitoring import MetricLabel, Metric
+from fast_abtest.exporter.prometheus import PrometheusExporter
 
 __version__ = "0.3.0"

--- a/fast_abtest/__init__.py
+++ b/fast_abtest/__init__.py
@@ -1,5 +1,23 @@
-from .decorator import ab_test
+from fast_abtest.decorator import ab_test
 from fast_abtest.monitoring import MetricLabel, Metric
-from fast_abtest.exporter.prometheus import PrometheusExporter
+from fast_abtest.interface import Exporter, Context, Metric as IMetric
+from fast_abtest.config import ABTestConfig, ConfigManager
+
+from fast_abtest.exporter.prometheus import PrometheusExporter as _PrometheusExporter
 
 __version__ = "0.3.0"
+__version_info__ = (0, 3, 0)
+
+__all__ = [
+    "ab_test",
+    "Metric",
+    "MetricLabel",
+    "Exporter",
+    "Context",
+    "ABTestConfig",
+    "ConfigManager",
+    "PrometheusExporter",
+    "IMetric",
+]
+
+PrometheusExporter = _PrometheusExporter

--- a/fast_abtest/config.py
+++ b/fast_abtest/config.py
@@ -1,0 +1,84 @@
+import os
+
+
+class ABTestConfig:
+    """Configuration class for A/B testing library settings.
+
+    Provides immutable configuration for Prometheus exporter and metric collection.
+    Supports initialization from environment variables via from_env() classmethod.
+
+    Attributes:
+        prometheus_port (int): Port for Prometheus metrics server (1024-65535)
+        default_labels (list[str]): Default metric label names for all exporters
+        histogram_buckets (list[float]): Bucket values for histogram metrics
+
+    Examples:
+       config = ABTestConfig(prometheus_port=9000)
+       env_config = ABTestConfig.from_env()
+    """
+
+    __slots__ = ("prometheus_port", "default_labels", "histogram_buckets", "extra")
+
+    def __init__(
+        self,
+        *,
+        prometheus_port: int = 8009,
+        default_labels: list[str] | None = None,
+        histogram_buckets: list[float] | None = None,
+    ):
+        self.prometheus_port = self._validate_port(prometheus_port)
+        self.default_labels = default_labels or ["variant", "func", "metric"]
+        self.histogram_buckets = histogram_buckets or [0.1, 0.5, 1.0, 2.0, 5.0]
+
+    def __setattr__(self, name, value):
+        if hasattr(self, name):
+            raise AttributeError("Configuration is immutable")
+        super().__setattr__(name, value)
+
+    @staticmethod
+    def _validate_port(value: int) -> int:
+        if not 1024 <= value <= 65535:
+            raise ValueError("Port must be between 1024 and 65535")
+        return value
+
+    @classmethod
+    def from_env(cls: type["ABTestConfig"]) -> "ABTestConfig":
+        """Create configuration from environment variables.
+
+        Reads:
+            ABTEST_PORT: Prometheus exporter port (default: 8009)
+            ABTEST_LABELS: Comma-separated default labels
+            ABTEST_BUCKETS: Comma-separated histogram bucket values
+
+        Returns:
+            New ABTestConfig instance populated from environment
+        """
+        return cls(
+            prometheus_port=int(os.getenv("ABTEST_PORT", "8009")),
+            default_labels=os.getenv("ABTEST_LABELS", "0").split(",") or None,
+            histogram_buckets=[float(value) for value in os.getenv("ABTEST_BUCKETS", "0").split(",")]
+            or [0.1, 0.5, 1.0, 2.0, 5.0],
+        )
+
+
+class ConfigManager:
+    """Global configuration manager for A/B testing library.
+
+    Maintains and provides access to the current configuration state.
+    Allows safe updates through the update_config() method.
+
+    Example:
+        ConfigManager.update_config(prometheus_port=9000)
+        current_config = ConfigManager.get_config()
+    """
+
+    _current_config: ABTestConfig = ABTestConfig()
+
+    @classmethod
+    def get_config(cls: type["ConfigManager"]) -> ABTestConfig:
+        return cls._current_config
+
+    @classmethod
+    def update_config(cls: type["ConfigManager"], **params) -> None:
+        current = cls._current_config.__dict__
+        cls._current_config = ABTestConfig(**current, **params)

--- a/fast_abtest/decorator.py
+++ b/fast_abtest/decorator.py
@@ -23,7 +23,7 @@ def _get_metric_class_name(metric: type[Metric] | MetricEnum):
 
 def _create_registered_scenario(
     func: ScenarioHandler[R],
-    metrics: Iterable[type[Metric]],
+    metrics: Iterable[type[Metric] | MetricEnum],
     exporter: type[Exporter],
     logger: Logger,
 ) -> RegisteredScenario[R]:
@@ -36,6 +36,7 @@ def _create_registered_scenario(
     metric_names = [_get_metric_class_name(metric) for metric in metrics]
     initialized_exporter = exporter(
         metrics=metric_names,
+        func_name=func.__name__,
         labelnames=config.default_labels,
         port=config.prometheus_port,
     )

--- a/fast_abtest/exporter/__init__.py
+++ b/fast_abtest/exporter/__init__.py
@@ -1,0 +1,1 @@
+from .prometheus import PrometheusExporter

--- a/fast_abtest/exporter/prometheus.py
+++ b/fast_abtest/exporter/prometheus.py
@@ -1,0 +1,58 @@
+from threading import Lock
+from typing import Self, Iterable
+
+from prometheus_client import Counter, Histogram
+
+from fast_abtest import MetricLabel
+from fast_abtest.interface import Metric
+
+
+class PrometheusExporter:
+    def __init__(
+        self: Self,
+        metrics: list[Metric],
+        lablenames: Iterable[str],
+    ) -> None:
+        self._metrics: dict[str, Counter] = {}
+        self._histograms: dict[str, Histogram] = {}
+        for metric in metrics:
+            self._add_metric(metric)
+        self._lock = Lock()
+        self._labelnames = lablenames
+
+    def record(
+        self: Self,
+        label: MetricLabel,
+        value: float | int,
+    ) -> None:
+        if not all(tag in self._labelnames for tag in label.tags):
+            raise ValueError(f"Unknown tags: {label.tags}. Expected: {self._labelnames}")
+
+        labels = {tag: getattr(label, tag, "") for tag in self._labelnames}
+        if label.metric.endswith("latency"):
+            self._histograms[label.metric].labels(**labels).observe(value)
+        else:
+            self._metrics[label.metric].labels(**labels).inc()
+
+    def _add_metric(
+        self: Self,
+        metric: Metric,
+    ) -> None:
+        metric_name = str(metric)
+        with self._lock:
+            if metric_name in (self._histograms if "latency" in metric_name.lower() else self._metrics):
+                return
+
+            if "latency" in metric_name.lower():
+                self._histograms[metric_name] = Histogram(
+                    name=metric_name,
+                    documentation=f"{metric_name} ('histogram')",
+                    buckets=[0.1, 0.5, 1.0, 2.0, 5.0],
+                    labelnames=self._labelnames,
+                )
+            else:
+                self._metrics[metric_name] = Counter(
+                    name=metric_name,
+                    documentation=f"{metric_name} ('counter')",
+                    labelnames=self._labelnames,
+                )

--- a/fast_abtest/exporter/prometheus.py
+++ b/fast_abtest/exporter/prometheus.py
@@ -3,45 +3,58 @@ from typing import Self, Iterable
 
 from prometheus_client import Counter, Histogram
 
-from fast_abtest import MetricLabel
-from fast_abtest.interface import Metric
+from fast_abtest.monitoring.interface import MetricLabel
 
 
 class PrometheusExporter:
+    REQUIRED_LABELS = {"variant", "func", "metric"}
+
     def __init__(
         self: Self,
-        metrics: list[Metric],
-        lablenames: Iterable[str],
+        metrics: Iterable[str],
+        func_name: str,
+        labelnames: Iterable[str],
+        port: int,
     ) -> None:
+        from prometheus_client import start_http_server
+
+        start_http_server(port)
+
         self._metrics: dict[str, Counter] = {}
+        self._func_name = func_name
         self._histograms: dict[str, Histogram] = {}
+        self._lock = Lock()
+        self._labelnames = set(labelnames).union(self.REQUIRED_LABELS)
         for metric in metrics:
             self._add_metric(metric)
-        self._lock = Lock()
-        self._labelnames = lablenames
 
-    def record(
-        self: Self,
-        label: MetricLabel,
-        value: float | int,
-    ) -> None:
-        if not all(tag in self._labelnames for tag in label.tags):
-            raise ValueError(f"Unknown tags: {label.tags}. Expected: {self._labelnames}")
-
-        labels = {tag: getattr(label, tag, "") for tag in self._labelnames}
-        if label.metric.endswith("latency"):
-            self._histograms[label.metric].labels(**labels).observe(value)
+    def record(self: Self, label: MetricLabel, value: float | int) -> None:
+        """Records a metric value with labels.
+        Args:
+            label: MetricLabel containing required fields (variant, func, metric)
+                  and optional tags.
+            value: Numeric value to record.
+        Note:
+            Only tags present in `labelnames` will be used.
+        """
+        metric_name = f"abtest_{self._func_name}_{label.metric}"
+        base_labels = {"variant": label.variant, "func": label.func, "metric": metric_name}
+        extra_labels = {k: v for k, v in label.tags.items() if k in self._labelnames}
+        missing_labels = {k: "" for k in self._labelnames if k not in base_labels and k not in extra_labels}
+        labels = {**base_labels, **extra_labels, **missing_labels}
+        if "latency" in metric_name.lower():
+            self._histograms[metric_name].labels(**labels).observe(value)
         else:
-            self._metrics[label.metric].labels(**labels).inc()
+            self._metrics[metric_name].labels(**labels).inc()
 
     def _add_metric(
         self: Self,
-        metric: Metric,
+        metric_name: str,
     ) -> None:
-        metric_name = str(metric)
+        metric_name = f"abtest_{self._func_name}_{metric_name}"
         with self._lock:
-            if metric_name in (self._histograms if "latency" in metric_name.lower() else self._metrics):
-                return
+            # if metric_name in (self._histograms if "latency" in metric_name.lower() else self._metrics):
+            #     return
 
             if "latency" in metric_name.lower():
                 self._histograms[metric_name] = Histogram(

--- a/fast_abtest/exporter/prometheus.py
+++ b/fast_abtest/exporter/prometheus.py
@@ -53,9 +53,6 @@ class PrometheusExporter:
     ) -> None:
         metric_name = f"abtest_{self._func_name}_{metric_name}"
         with self._lock:
-            # if metric_name in (self._histograms if "latency" in metric_name.lower() else self._metrics):
-            #     return
-
             if "latency" in metric_name.lower():
                 self._histograms[metric_name] = Histogram(
                     name=metric_name,

--- a/fast_abtest/interface.py
+++ b/fast_abtest/interface.py
@@ -1,6 +1,40 @@
-from typing import Protocol, Callable, Self, runtime_checkable
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import Protocol, Callable, TypeVar, Generic, Self
 
-from fast_abtest.registred_scenario import R, ScenarioHandler, Context
+from fast_abtest.monitoring.interface import Exporter, Context
+
+R = TypeVar("R")
+R_co = TypeVar("R_co", covariant=True)
+
+
+class ScenarioHandler(Protocol[R_co]):
+    __name__: str
+
+    def __call__(self, *args, **kwargs) -> R_co: ...
+
+
+@dataclass
+class _ScenarioVariant(Generic[R]):
+    handler: ScenarioHandler[R]
+    traffic_percent: int
+    threshold: float
+    call_count: int = 0
+    error_count: int = 0
+    is_active: bool = True
+    _lock: Lock = field(default_factory=Lock, init=False)
+
+    def increment_call(self: Self) -> None:
+        with self._lock:
+            self.call_count += 1
+
+    def threshold_exceeded(self: Self) -> bool:
+        with self._lock:
+            self.error_count += 1
+            if self.call_count > 10 and self.error_count / max(self.call_count, 1) > self.threshold:
+                self.is_active = False
+                return True
+        return False
 
 
 class ABTestFunction(Protocol[R]):
@@ -15,8 +49,12 @@ class ABTestFunction(Protocol[R]):
     def enable_variant(self: Self, variant_name: str) -> None: ...
 
 
-@runtime_checkable
 class Metric(Protocol):
+    def __init__(
+        self: Self,
+        exporter: Exporter,  # noqa
+    ) -> None: ...
+
     def on_start(self: Self, context: Context) -> Context: ...
 
     def on_end(self: Self, context: Context, is_error: bool) -> None: ...

--- a/fast_abtest/interface.py
+++ b/fast_abtest/interface.py
@@ -1,4 +1,4 @@
-from typing import Protocol, Callable, Self
+from typing import Protocol, Callable, Self, runtime_checkable
 
 from fast_abtest.registred_scenario import R, ScenarioHandler, Context
 
@@ -15,7 +15,8 @@ class ABTestFunction(Protocol[R]):
     def enable_variant(self: Self, variant_name: str) -> None: ...
 
 
+@runtime_checkable
 class Metric(Protocol):
-    def on_start(self: Self, context: Context) -> None: ...
+    def on_start(self: Self, context: Context) -> Context: ...
 
     def on_end(self: Self, context: Context, is_error: bool) -> None: ...

--- a/fast_abtest/monitoring/__init__.py
+++ b/fast_abtest/monitoring/__init__.py
@@ -1,2 +1,2 @@
-from metrics import Metric
-from interface import MetricLabel
+from .metrics import Metric
+from .interface import MetricLabel

--- a/fast_abtest/monitoring/calls_counter.py
+++ b/fast_abtest/monitoring/calls_counter.py
@@ -1,20 +1,22 @@
 from typing import Self
 
-from fast_abtest.monitoring.interface import Exporter, MetricLabel
+from fast_abtest.monitoring.interface import Exporter, MetricLabel, BaseMetric
 from fast_abtest.registred_scenario import Context
 
 
-class CallsMetric:
+class CallsMetric(BaseMetric):
     def __init__(self: Self, exporter: Exporter) -> None:
-        self._exporter = exporter
+        super().__init__(exporter)
+        self._calls = 0
 
-    def on_start(self: Self, context: Context) -> None:
+    def on_start(self: Self, context: Context) -> Context:
+        with self._lock:
+            self._calls += 1
         label = MetricLabel(
-            metric="calls_total",
+            metric=self.__class__.__name__,
             func=context.scenario,
             variant=context.variant,
             is_error=False,
         )
         self._exporter.record(label=label, value=1)
-
-    def on_end(self: Self, context: Context, is_error: bool) -> None: ...
+        return context

--- a/fast_abtest/monitoring/errors_counter.py
+++ b/fast_abtest/monitoring/errors_counter.py
@@ -1,19 +1,20 @@
 from typing import Self
 
-from fast_abtest.monitoring.interface import Exporter, MetricLabel
+from fast_abtest.monitoring.interface import MetricLabel, Exporter, BaseMetric
 from fast_abtest.registred_scenario import Context
 
 
-class ErrorsMetric:
+class ErrorsMetric(BaseMetric):
     def __init__(self: Self, exporter: Exporter) -> None:
-        self._exporter = exporter
-
-    def on_start(self: Self, context: Context) -> None: ...
+        super().__init__(exporter)
+        self._errors = 0
 
     def on_end(self: Self, context: Context, is_error: bool) -> None:
         if is_error:
+            with self._lock:
+                self._errors += 1
             label = MetricLabel(
-                metric="errors_total",
+                metric=self.__class__.__name__,
                 func=context.scenario,
                 variant=context.variant,
                 is_error=True,

--- a/fast_abtest/monitoring/interface.py
+++ b/fast_abtest/monitoring/interface.py
@@ -1,8 +1,14 @@
 from dataclasses import dataclass, field
 from threading import Lock
-from typing import Protocol, Self, Any
+from typing import Protocol, Self, Iterable
 
-from fast_abtest.registred_scenario import Context
+
+@dataclass
+class Context:
+    scenario: str
+    variant: str
+    timestamp: int
+    extra: dict = field(default_factory=dict)
 
 
 @dataclass
@@ -15,7 +21,14 @@ class MetricLabel:
 
 
 class Exporter(Protocol):
-    def record(self: Self, label: MetricLabel, value: float | int): ...
+    def __init__(
+        self: Self,
+        metrics: Iterable[str],  # noqa
+        labelnames: Iterable[str],  # noqa
+        port: int,  # noqa
+    ) -> None: ...
+
+    def record(self: Self, label: MetricLabel, value: float | int) -> None: ...
 
 
 class BaseMetric:

--- a/fast_abtest/monitoring/interface.py
+++ b/fast_abtest/monitoring/interface.py
@@ -24,6 +24,7 @@ class Exporter(Protocol):
     def __init__(
         self: Self,
         metrics: Iterable[str],  # noqa
+        func_name: str,  # noqa
         labelnames: Iterable[str],  # noqa
         port: int,  # noqa
     ) -> None: ...

--- a/fast_abtest/monitoring/interface.py
+++ b/fast_abtest/monitoring/interface.py
@@ -15,7 +15,7 @@ class MetricLabel:
 
 
 class Exporter(Protocol):
-    def record(self: Self, label: MetricLabel, value: Any): ...
+    def record(self: Self, label: MetricLabel, value: float | int): ...
 
 
 class BaseMetric:

--- a/fast_abtest/monitoring/interface.py
+++ b/fast_abtest/monitoring/interface.py
@@ -1,5 +1,8 @@
 from dataclasses import dataclass, field
+from threading import Lock
 from typing import Protocol, Self, Any
+
+from fast_abtest.registred_scenario import Context
 
 
 @dataclass
@@ -13,3 +16,14 @@ class MetricLabel:
 
 class Exporter(Protocol):
     def record(self: Self, label: MetricLabel, value: Any): ...
+
+
+class BaseMetric:
+    def __init__(self: Self, exporter: Exporter) -> None:
+        self._exporter = exporter
+        self._lock = Lock()
+
+    def on_start(self: Self, context: Context) -> Context:
+        return context
+
+    def on_end(self: Self, context: Context, is_error: bool) -> None: ...

--- a/fast_abtest/monitoring/latency.py
+++ b/fast_abtest/monitoring/latency.py
@@ -1,22 +1,24 @@
+from contextvars import ContextVar
 from time import perf_counter
 from typing import Self
 
-from fast_abtest.monitoring.interface import Exporter, MetricLabel
+from fast_abtest.monitoring.interface import Exporter, MetricLabel, BaseMetric
 from fast_abtest.registred_scenario import Context
 
 
-class LatencyMetric:
+class LatencyMetric(BaseMetric):
     def __init__(self: Self, exporter: Exporter) -> None:
-        self._start_time: float = 0.0
-        self._exporter = exporter
+        super().__init__(exporter)
+        self._start_time: ContextVar[float] = ContextVar("start_time")
 
-    def on_start(self: Self, context: Context) -> None:
-        self._start_time = perf_counter()
+    def on_start(self: Self, context: Context) -> Context:
+        self._start_time.set(perf_counter())
+        return context
 
     def on_end(self: Self, context: Context, is_error: bool) -> None:
-        latency = perf_counter() - self._start_time
+        latency = perf_counter() - self._start_time.get()
         label = MetricLabel(
-            metric="latency",
+            metric=self.__class__.__name__,
             func=context.scenario,
             variant=context.variant,
             is_error=is_error,

--- a/fast_abtest/monitoring/metrics.py
+++ b/fast_abtest/monitoring/metrics.py
@@ -1,6 +1,15 @@
 from enum import Enum
+from typing import Self
+
+from fast_abtest.monitoring.calls_counter import CallsMetric
+from fast_abtest.monitoring.errors_counter import ErrorsMetric
+from fast_abtest.monitoring.latency import LatencyMetric
 
 
 class Metric(Enum):
-    LATENCY = 1
-    ERROR_RATE = 2
+    LATENCY = LatencyMetric
+    CALLS_TOTAL = CallsMetric
+    ERRORS_TOTAL = ErrorsMetric
+
+    def __str__(self: Self) -> str:
+        return str(self.value)

--- a/fast_abtest/monitoring/metrics.py
+++ b/fast_abtest/monitoring/metrics.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from typing import Self
 
+from fast_abtest.interface import Metric as IMetric
 from fast_abtest.monitoring.calls_counter import CallsMetric
 from fast_abtest.monitoring.errors_counter import ErrorsMetric
 from fast_abtest.monitoring.latency import LatencyMetric
@@ -13,3 +14,6 @@ class Metric(Enum):
 
     def __str__(self: Self) -> str:
         return str(self.value)
+
+    def __call__(self, *args, **kwargs) -> IMetric:
+        return self.value(*args, **kwargs)

--- a/fast_abtest/monitoring/recorder.py
+++ b/fast_abtest/monitoring/recorder.py
@@ -1,4 +1,4 @@
-from typing import Self
+from typing import Self, Iterable
 
 from fast_abtest.interface import Metric
 from fast_abtest.registred_scenario import Context
@@ -7,7 +7,7 @@ from fast_abtest.registred_scenario import Context
 class MetricRecorder:
     def __init__(
         self: Self,
-        metrics: list[Metric],
+        metrics: Iterable[Metric],
         context: Context,
     ) -> None:
         self._metrics = metrics
@@ -15,7 +15,7 @@ class MetricRecorder:
 
     def __enter__(self: Self) -> Self:
         for metric in self._metrics:
-            metric.on_start(context=self._context)
+            self._context = metric.on_start(context=self._context)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:

--- a/fast_abtest/registred_scenario.py
+++ b/fast_abtest/registred_scenario.py
@@ -7,6 +7,7 @@ from typing import Callable, TypeVar, Generic, Protocol, Iterable
 
 from typing_extensions import Self
 
+from fast_abtest.monitoring.interface import Exporter, BaseMetric
 from fast_abtest.monitoring.metrics import Metric
 
 R = TypeVar("R")
@@ -58,7 +59,7 @@ class RegisteredScenario(Generic[R]):
     def __init__(
         self: Self,
         main_scenario: _ScenarioVariant[R],
-        metrics: Iterable[Metric | Callable],
+        metrics: Iterable[Metric],
         logger: Logger,
     ) -> None:
         self._variants: list[_ScenarioVariant[R]] = []

--- a/fast_abtest/registred_scenario.py
+++ b/fast_abtest/registred_scenario.py
@@ -53,7 +53,7 @@ class _ScenarioVariant(Generic[R]):
 
 
 class RegisteredScenario(Generic[R]):
-    EXCEEDING_THRESHOLD_WARNING = "Variant {} disabled by error rate (error rate: {:.2}"
+    EXCEEDING_THRESHOLD_WARNING = "Variant {} disabled by error rate (error rate: {:.2})"
 
     def __init__(
         self: Self,

--- a/fast_abtest/registred_scenario.py
+++ b/fast_abtest/registred_scenario.py
@@ -1,56 +1,12 @@
 import inspect
-from dataclasses import dataclass, field
+import time
 from logging import Logger
-from random import randint
-from threading import Lock
-from typing import Callable, TypeVar, Generic, Protocol, Iterable
+from typing import Callable, Generic, Iterable, Self
 
-from typing_extensions import Self
-
-from fast_abtest.monitoring.interface import Exporter, BaseMetric
-from fast_abtest.monitoring.metrics import Metric
-
-R = TypeVar("R")
-R_co = TypeVar("R_co", covariant=True)
-
-
-class ScenarioHandler(Protocol[R_co]):
-    __name__: str
-
-    def __call__(self, *args, **kwargs) -> R_co: ...
-
-
-@dataclass
-class Context:
-    scenario: str
-    variant: str
-    timestamp: int
-    args: tuple
-    kwargs: dict
-    extra: dict
-
-
-@dataclass
-class _ScenarioVariant(Generic[R]):
-    handler: ScenarioHandler[R]
-    traffic_percent: int
-    threshold: float
-    call_count: int = 0
-    error_count: int = 0
-    is_active: bool = True
-    _lock: Lock = field(default_factory=Lock, init=False)
-
-    def increment_call(self: Self) -> None:
-        with self._lock:
-            self.call_count += 1
-
-    def threshold_exceeded(self: Self) -> bool:
-        with self._lock:
-            self.error_count += 1
-            if self.call_count > 10 and self.error_count / max(self.call_count, 1) > self.threshold:
-                self.is_active = False
-                return True
-        return False
+from fast_abtest.interface import R, ScenarioHandler, _ScenarioVariant, Metric
+from fast_abtest.monitoring.interface import Context
+from fast_abtest.monitoring.recorder import MetricRecorder
+from fast_abtest.variant_selector import VariantSelector
 
 
 class RegisteredScenario(Generic[R]):
@@ -61,13 +17,16 @@ class RegisteredScenario(Generic[R]):
         main_scenario: _ScenarioVariant[R],
         metrics: Iterable[Metric],
         logger: Logger,
+        idempotent: bool = False,
     ) -> None:
         self._variants: list[_ScenarioVariant[R]] = []
-        self._metrics = metrics
+        self._metric_recorder = MetricRecorder(metrics, logger)
         self._main_scenario = main_scenario
         self._main_scenario_signature = self._normalize_signature(inspect.signature(self._main_scenario.handler))
+        self._variant_selector: VariantSelector | None = None
         self._is_async = inspect.iscoroutinefunction(self._main_scenario.handler)
         self._logger = logger
+        self._idempotent = idempotent
 
     def register_variant(
         self: Self,
@@ -147,24 +106,22 @@ class RegisteredScenario(Generic[R]):
         *args,
         **kwargs,
     ) -> R:
-        rand = randint(1, 100)
-        current = 0
-        for variant in self._variants:
-            if not variant.is_active:
-                continue
-
-            current += variant.traffic_percent
-            if rand <= current:
-                variant.increment_call()
-                try:
-                    return variant.handler(*args, **kwargs)
-                except:
-                    if variant.threshold_exceeded():
-                        msg = self.EXCEEDING_THRESHOLD_WARNING.format(
-                            variant.handler.__name__,
-                            variant.error_count / variant.call_count,
-                        )
-                        self._logger.warning(msg)
-                    raise
-
-        return self._main_scenario.handler(*args, **kwargs)
+        if self._variant_selector is None:
+            self._variant_selector = VariantSelector(self._main_scenario, self._variants, self._idempotent)
+        variant: _ScenarioVariant[R] = self._variant_selector.select()
+        context = Context(
+            scenario=self._main_scenario.handler.__name__,
+            variant=variant.handler.__name__,
+            timestamp=int(time.time()),
+        )
+        with self._metric_recorder.record(context):
+            try:
+                return variant.handler(*args, **kwargs)
+            except:
+                if variant.threshold_exceeded():
+                    msg = self.EXCEEDING_THRESHOLD_WARNING.format(
+                        variant.handler.__name__,
+                        variant.error_count / variant.call_count,
+                    )
+                    self._logger.warning(msg)
+                raise

--- a/fast_abtest/variant_selector.py
+++ b/fast_abtest/variant_selector.py
@@ -1,26 +1,26 @@
 from random import randint
 from typing import Self, Iterable
 
-from fast_abtest.registred_scenario import _ScenarioVariant, ScenarioHandler
+from fast_abtest.interface import _ScenarioVariant
 
 
-class VariantSelector:
+class VariantSelector[R]:
     def __init__(
         self: Self,
-        main_scenario: _ScenarioVariant,
-        variants: Iterable[_ScenarioVariant],
+        main_scenario: _ScenarioVariant[R],
+        variants: Iterable[_ScenarioVariant[R]],
         idempotent: bool = False,
     ) -> None:
         self._variants = variants
         self._default_variant = main_scenario
         self._idempotent = idempotent
 
-    def select(self: Self) -> ScenarioHandler:
+    def select(self: Self) -> _ScenarioVariant[R]:
         if self._idempotent:
             return self._idempotent_select()
         return self._random_select()
 
-    def _random_select(self: Self) -> ScenarioHandler:
+    def _random_select(self: Self) -> _ScenarioVariant[R]:
         rand = randint(1, 100)
         current = 0
         for variant in self._variants:
@@ -30,9 +30,9 @@ class VariantSelector:
             current += variant.traffic_percent
             if rand <= current:
                 variant.increment_call()
-                return variant.handler
+                return variant
 
-        return self._default_variant.handler
+        return self._default_variant
 
-    def _idempotent_select(self: Self) -> ScenarioHandler:
-        return self._default_variant.handler
+    def _idempotent_select(self: Self) -> _ScenarioVariant[R]:
+        return self._default_variant

--- a/fast_abtest/variant_selector.py
+++ b/fast_abtest/variant_selector.py
@@ -1,0 +1,38 @@
+from random import randint
+from typing import Self, Iterable
+
+from fast_abtest.registred_scenario import _ScenarioVariant, ScenarioHandler
+
+
+class VariantSelector:
+    def __init__(
+        self: Self,
+        main_scenario: _ScenarioVariant,
+        variants: Iterable[_ScenarioVariant],
+        idempotent: bool = False,
+    ) -> None:
+        self._variants = variants
+        self._default_variant = main_scenario
+        self._idempotent = idempotent
+
+    def select(self: Self) -> ScenarioHandler:
+        if self._idempotent:
+            return self._idempotent_select()
+        return self._random_select()
+
+    def _random_select(self: Self) -> ScenarioHandler:
+        rand = randint(1, 100)
+        current = 0
+        for variant in self._variants:
+            if not variant.is_active:
+                continue
+
+            current += variant.traffic_percent
+            if rand <= current:
+                variant.increment_call()
+                return variant.handler
+
+        return self._default_variant.handler
+
+    def _idempotent_select(self: Self) -> ScenarioHandler:
+        return self._default_variant.handler

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ target-version = ["py310"]
 
 [tool.poetry.dependencies]
 python = "^3.10"
+prometheus-client = "^0.22.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0"

--- a/tests/test_custom_metric.py
+++ b/tests/test_custom_metric.py
@@ -1,0 +1,115 @@
+import pytest
+from typing import Any
+from fast_abtest import ab_test, Exporter, Context, Metric
+from fast_abtest.config import ABTestConfig
+from fast_abtest.monitoring import MetricLabel
+
+
+class CustomMetric:
+    def __init__(self, exporter: Exporter):
+        self._exporter = exporter
+        self.start_context = None
+        self.end_calls = 0
+
+    def on_start(self, context: Context) -> Context:
+        self.start_context = context
+        return context
+
+    def on_end(self, context: Context, is_error: bool) -> None:
+        self.end_calls += 1
+        self._exporter.record(
+            label=MetricLabel(
+                metric=self.__class__.__name__,
+                func=context.scenario,
+                variant=context.variant,
+                is_error=is_error,
+                tags={"custom_tag": "test"},
+            ),
+            value=1.0,
+        )
+
+
+@pytest.fixture
+def custom_metric_class():
+    return CustomMetric
+
+
+@pytest.fixture
+def test_config():
+    return ABTestConfig(prometheus_port=9093)
+
+
+def test_custom_metric_integration(custom_metric_class, test_config) -> None:
+    """Test the integration of a custom metric with a decorator."""
+
+    @ab_test(metrics=[custom_metric_class])
+    def test_function():
+        return "success"
+
+    result = test_function()
+    assert result == "success"
+
+    metric_instance = test_function._metric_recorder._metrics[0]
+    assert metric_instance.start_context is not None
+    assert metric_instance.end_calls == 1
+
+
+def test_custom_metric_with_fastapi(custom_metric_class, test_config):
+    """Test the operation in the asynchronous FastAPI endpoint."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    app = FastAPI()
+
+    @app.get("/test")
+    @ab_test(metrics=[custom_metric_class])
+    async def test_endpoint():
+        return {"status": "ok"}
+
+    client = TestClient(app)
+    response = client.get("/test")
+    assert response.status_code == 200
+
+    metric_instance = test_endpoint._metric_recorder._metrics[0]
+    assert metric_instance.end_calls == 1
+    assert "test_endpoint" in str(metric_instance.start_context.scenario)
+
+
+def test_custom_metric_with_exporter(custom_metric_class, test_config):
+    """Test the custom metric is used correctly by the exporter."""
+
+    class MockExporter:
+        def __init__(self):
+            self.recorded = []
+
+        def record(self, label: MetricLabel, value: float | int) -> None:
+            self.recorded.append((label, value))
+
+    mock_exporter = MockExporter()
+    metric = custom_metric_class(mock_exporter)
+    test_context = Context(scenario="test", variant="A", timestamp=123)
+
+    metric.on_start(test_context)
+    metric.on_end(test_context, is_error=False)
+
+    assert len(mock_exporter.recorded) == 1
+    label, value = mock_exporter.recorded[0]
+    assert label.metric == "CustomMetric"
+    assert value == 1.0
+
+
+def test_metric_names_uniqueness():
+    """Test the possibility of creating multiple branches of variants without label conflict"""
+
+    @ab_test(metrics=[Metric.LATENCY])
+    def func1():
+        pass
+
+    @ab_test(metrics=[Metric.LATENCY])
+    def func2():
+        pass
+
+    assert func1._metric_recorder._metrics[0]._exporter._func_name == "func1"
+    assert func2._metric_recorder._metrics[0]._exporter._func_name == "func2"
+    assert any("func1_Latency" in metric for metric in func1._metric_recorder._metrics[0]._exporter._histograms)
+    assert any("func2_Latency" in metric for metric in func2._metric_recorder._metrics[0]._exporter._histograms)

--- a/tests/test_error_rate_threshold.py
+++ b/tests/test_error_rate_threshold.py
@@ -174,7 +174,7 @@ def test_threshold_precision_with_threads(reset_random):
     def precision_endpoint():
         return "ok"
 
-    @precision_endpoint.register_variant(traffic_percent=80, disable_threshold=0.4)
+    @precision_endpoint.register_variant(traffic_percent=80, disable_threshold=0.5)
     def variant_b():
         if threading.get_ident() % 3 == 0:
             raise RuntimeError("Thread error")

--- a/tests/test_prometheus_exporter.py
+++ b/tests/test_prometheus_exporter.py
@@ -1,0 +1,162 @@
+import pytest
+import requests
+from fastapi import FastAPI
+from threading import Thread
+from fast_abtest import PrometheusExporter, MetricLabel, Metric
+from fast_abtest.config import ABTestConfig
+
+
+@pytest.fixture(scope="module")
+def prometheus_exporter():
+    exporter = PrometheusExporter(
+        metrics=[Metric.CALLS_TOTAL.value.__name__, Metric.ERRORS_TOTAL.value.__name__, Metric.LATENCY.value.__name__],
+        func_name="test_metrics",
+        labelnames=["endpoint", "status"],
+        port=9091,
+    )
+    yield exporter
+
+
+@pytest.fixture(scope="module")
+def test_app(prometheus_exporter):
+    app = FastAPI()
+
+    @app.get("/test")
+    async def test_route(status: str = "success"):
+        prometheus_exporter.record(
+            label=MetricLabel(
+                metric=Metric.CALLS_TOTAL.value.__name__,
+                func="test_route",
+                variant="v1",
+                is_error=(status == "error"),
+                tags={"endpoint": "/test", "status": status},
+            ),
+            value=1,
+        )
+        return {"status": status}
+
+    return app
+
+
+@pytest.fixture(scope="module")
+def test_client(test_app):
+    import uvicorn
+
+    server_thread = Thread(
+        target=uvicorn.run,
+        args=(test_app,),
+        kwargs={"host": "localhost", "port": 9090},
+        daemon=True,
+    )
+    server_thread.start()
+    yield requests.Session()
+
+
+def test_exporter_setup(prometheus_exporter):
+    """Test the initialization of metrics"""
+    for metric in [Metric.ERRORS_TOTAL.value.__name__, Metric.CALLS_TOTAL.value.__name__]:
+        assert f"abtest_test_metrics_{metric}" in prometheus_exporter._metrics
+
+    assert f"abtest_test_metrics_{Metric.LATENCY.value.__name__}" in prometheus_exporter._histograms
+    assert prometheus_exporter._labelnames == {"variant", "func", "metric", "endpoint", "status"}
+
+
+def test_record_metric(prometheus_exporter):
+    """Test the recording of metrics"""
+    base_metric = Metric.CALLS_TOTAL.value.__name__
+    metric_name = f"test_metrics_{base_metric}"
+
+    func = "sample_func"
+    variant = "A"
+    endpoint = "/sample"
+    status = "200"
+
+    prometheus_exporter.record(
+        label=MetricLabel(
+            metric=base_metric,
+            func=func,
+            variant=variant,
+            is_error=False,
+            tags={"endpoint": endpoint, "status": status},
+        ),
+        value=1,
+    )
+
+    response = requests.get("http://localhost:9091/metrics")
+    result = "abtest_" + metric_name
+    assert result in response.text
+
+
+def test_fastapi_integration(test_client, prometheus_exporter):
+    """Test the generation of metrics when calling FastAPI router"""
+    response = test_client.get("http://localhost:9090/test?status=success")
+    assert response.json()["status"] == "success"
+
+    metrics_response = requests.get("http://localhost:9091/metrics")
+    metrics = metrics_response.text
+
+    expected_metric = f"test_metrics_{Metric.CALLS_TOTAL.value.__name__}_total"
+    assert expected_metric in metrics and 'status="success"' in metrics
+    assert expected_metric in metrics and 'status="error"' not in metrics
+
+
+def test_missing_labels(prometheus_exporter):
+    """Test the handling of the absence of optional labels."""
+    base_metric = Metric.CALLS_TOTAL.value.__name__
+    prometheus_exporter.record(
+        label=MetricLabel(
+            metric=base_metric,
+            func="no_tags_func",
+            variant="B",
+            is_error=False,
+        ),
+        value=1,
+    )
+
+    metrics = requests.get("http://localhost:9091/metrics").text
+    expected_metric = f"test_metrics_{base_metric}_total"
+    assert expected_metric in metrics
+    assert "no_tags_func" in metrics
+    assert 'endpoint=""' in metrics
+
+
+def test_invalid_port():
+    """Test that ABTestConfig rejects invalid ports"""
+    with pytest.raises(ValueError, match="Port must be between 1024 and 65535"):
+        ABTestConfig(prometheus_port=99999)
+
+    with pytest.raises(ValueError):
+        ABTestConfig(prometheus_port=-1)
+
+
+def test_valid_port_config():
+    """Test that the port is being transmitted correctly through the configurator."""
+    config = ABTestConfig(prometheus_port=9091)
+    exporter = PrometheusExporter(
+        metrics=["test"],
+        func_name="test_func",
+        labelnames=[],
+        port=config.prometheus_port,
+    )
+    assert exporter._labelnames == {"variant", "func", "metric"}
+
+
+def test_metrics_format(prometheus_exporter):
+    """Test for compliance with the Prometheus format."""
+    base_metric = "LatencyMetric"
+    metric_name = f"test_metrics_{base_metric}"
+
+    prometheus_exporter.record(
+        label=MetricLabel(
+            metric=base_metric, func="timed_func", variant="C", is_error=False, tags={"endpoint": "/timed"}
+        ),
+        value=0.35,
+    )
+
+    metrics = requests.get("http://localhost:9091/metrics").text
+    bucket = f"{metric_name}_bucket"
+    count = f"{metric_name}_count"
+    sum_info = f"{metric_name}_sum"
+    assert bucket in metrics and 'le="0.5"' in metrics
+    assert count in metrics
+    assert sum_info in metrics


### PR DESCRIPTION
Basic monitoring has been implemented for all functions marked with the @ab_test decorator and registered variants. 
Basic metrics are implemented: number of calls, response time, number of errors. The IMetric interface for implementing custom metrics has been added. 
Added a basic metric exporter to prometheus with the ability to configure additional labels and a prometheus server port